### PR TITLE
Patch v0.1a | Fix https being used on cf page (#3)

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,1 @@
+USE_HTTPS = [true | false]

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ megalinter-reports/
 ssl
 
 dev-dist
+.env

--- a/global.d.ts
+++ b/global.d.ts
@@ -1,0 +1,6 @@
+declare namespace NodeJS {
+	interface ProcessEnv {
+		NODE_ENV: string;
+		USE_HTTPS: boolean;
+	}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
 				"@types/react-router-dom": "^5.3.3",
 				"@uidotdev/usehooks": "^2.4.1",
 				"@vitejs/plugin-basic-ssl": "^1.1.0",
+        "dotenv": "^16.4.5",
 				"ionicons": "^7.0.0",
 				"konsta": "^3.1.3",
 				"react": "^18.2.0",
@@ -5509,6 +5510,17 @@
 			},
 			"engines": {
 				"node": ">=12"
+			}
+		},
+    "node_modules/dotenv": {
+			"version": "16.4.5",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+			"integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://dotenvx.com"
 			}
 		},
 		"node_modules/eastasianwidth": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
 		"@types/react-router-dom": "^5.3.3",
 		"@uidotdev/usehooks": "^2.4.1",
 		"@vitejs/plugin-basic-ssl": "^1.1.0",
+    "dotenv": "^16.4.5",
 		"ionicons": "^7.0.0",
 		"konsta": "^3.1.3",
 		"react": "^18.2.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,7 +17,6 @@ import { Menu, Toolbar } from "./components";
 
 /* Core CSS required for Ionic components to work properly */
 import "@ionic/react/css/core.css";
-
 /* Basic CSS for apps built with Ionic */
 //!!! THIS CSS WILL BREAK THE KUI !!!
 // import "@ionic/react/css/normalize.css";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,21 +1,21 @@
 {
-  "compilerOptions": {
-    "target": "ESNext",
-    "useDefineForClassFields": true,
-    "lib": ["DOM", "DOM.Iterable", "ESNext"],
-    "allowJs": false,
-    "skipLibCheck": true,
-    "esModuleInterop": false,
-    "allowSyntheticDefaultImports": true,
-    "strict": true,
-    "forceConsistentCasingInFileNames": true,
-    "module": "ESNext",
-    "moduleResolution": "Node",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "noEmit": true,
-    "jsx": "react-jsx"
-  },
-  "include": ["src"],
-  "references": [{ "path": "./tsconfig.node.json" }]
+	"compilerOptions": {
+		"target": "ESNext",
+		"useDefineForClassFields": true,
+		"lib": ["DOM", "DOM.Iterable", "ESNext"],
+		"allowJs": false,
+		"skipLibCheck": true,
+		"esModuleInterop": false,
+		"allowSyntheticDefaultImports": true,
+		"strict": true,
+		"forceConsistentCasingInFileNames": true,
+		"module": "ESNext",
+		"moduleResolution": "Node",
+		"resolveJsonModule": true,
+		"isolatedModules": true,
+		"noEmit": true,
+		"jsx": "react-jsx",
+	},
+	"include": ["src"],
+	"references": [{ "path": "./tsconfig.node.json"}]
 }

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,9 +1,10 @@
 {
-  "compilerOptions": {
-    "composite": true,
-    "module": "ESNext",
-    "moduleResolution": "Node",
-    "allowSyntheticDefaultImports": true
-  },
-  "include": ["vite.config.ts"]
+	"compilerOptions": {
+		"composite": true,
+		"module": "ESNext",
+		"moduleResolution": "Node",
+		"allowSyntheticDefaultImports": true,
+		"typeRoots": ["global.d.ts"]
+	},
+	"include": ["vite.config.ts"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,13 +1,9 @@
 /// <reference types="vitest" />
-
-import legacy from "@vitejs/plugin-legacy";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
-import selfAssignCert from "@vitejs/plugin-basic-ssl";
 import { VitePWA } from "vite-plugin-pwa";
-import {
-	ServerOptions as HttpsServerOptions,
-} from "node:https";
+import { ServerOptions as HttpsServerOptions } from "node:https";
+import "dotenv/config";
 
 const https: HttpsServerOptions = {
 	key: "ssl/mTls/key.key",
@@ -19,13 +15,8 @@ const https: HttpsServerOptions = {
 export default defineConfig({
 	plugins: [
 		react(),
-		// legacy(),
 		VitePWA({
 			registerType: "autoUpdate",
-			// devOptions: {
-			// 	enabled: true,
-			// },
-			// mode: "development",
 		}),
 	],
 	test: {
@@ -35,6 +26,6 @@ export default defineConfig({
 	},
 	server: {
 		port: 8443,
-		https,
+		https: process.env.USE_HTTPS ? https : undefined,
 	},
 });


### PR DESCRIPTION
* init Time componet

* init Time page

* Android and PWA support

* Self assign cert implment

* specific preview port

* IOS and BLEsupport

* Fix android manifest targetAPI

* tailwind, MD3 support

* implment buzzer class

* implment ble lib

* implment basic UI

* Timer setting page

* stopplate base class

* implment Dragoncustom stoppplate connector

* implment control hook

* update api

* ui implment

* implemented setting

* impl timer cout down

* implment buzzzer using stopplate config

* Optimize the stopplate code

* implment timer function

* set the default state when clean up

* Fix the unregister function not working

* Fix type error

* fix cap:sync command

* Config the manifest

* add pwa

* Fix the ionic break the KUI

* PWA fix

* add .env